### PR TITLE
BKNDLSS-31603 [MapBox component] Search icon overlaps search text in the search field

### DIFF
--- a/components/bl-mapbox-component/styles/index.less
+++ b/components/bl-mapbox-component/styles/index.less
@@ -13,4 +13,8 @@
     width: 100%;
     height: if(@bl-customComponent-mapbox-height < 100%, 100%, inherit);
   }
+
+  .mapboxgl-ctrl-geocoder--input {
+    padding: 10px 10px 10px 30px !important;
+  }
 }


### PR DESCRIPTION
We use the `mapbox-geocder.js` library for the search field, which creates input with `mapboxgl-ctrl-geocoder--input` class. Also, we use `mapbox-directions.js` for directions, this adds styling `.mapboxgl-ctrl-geocoder input[type=text]`, which applies to both inputs and it's overwriting the previous class.